### PR TITLE
Fix segmentation fault in cidrsubnets function

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -177,8 +177,8 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 				return rsp, nil
 			}
 		}
-		cidrs, cidrSubnetsErr := CidrSubnets(prefix, newBits...)
-		if cidrSubnetsErr != nil {
+		cidrs, err := CidrSubnets(prefix, newBits...)
+		if err != nil {
 			response.Fatal(rsp, errors.Wrapf(err, "cannot calculate Subnet CIDRs for %s", oxr.Resource.GetKind()))
 			return rsp, nil
 		}


### PR DESCRIPTION
This change is necessary to prevent the cidrsubnets function segfault when overflowing the available range

fixes: https://github.com/upbound/function-cidr/issues/30

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
