### PR TITLE
Use distroless/static image instead of distroless/base since glibc is not used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN --mount=target=. \
 
 # Produce the Function image. We use a very lightweight 'distroless' image that
 # does not include any of the build tools used in previous stages.
-FROM gcr.io/distroless/base-debian11 AS image
+FROM gcr.io/distroless/static-debian12:nonroot AS image
 WORKDIR /
 COPY --from=build /function /function
 EXPOSE 9443


### PR DESCRIPTION
### Description of your changes

This pull request changes the base image of the function to `gcr.io/distroless/static-debian12:nonroot`.

Fixes #43

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
  ```
  make: *** No rule to make target 'reviewable'.  Stop.
  ```
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

I've built the function using the modified `Dockerfile` and run the `render` and `render-pipeline` targets. Both ran without errors — as expected.

* Output of `make render`:
  ```
  Rendering examples/xr-cidrhost.yaml...
  ---
  apiVersion: platform.upbound.io/v1alpha1
  kind: XCIDR
  metadata:
    name: cidr-host
  status:
    atFunction:
      cidr: 10.0.0.111
    conditions:
    - lastTransitionTime: "2024-01-01T00:00:00Z"
      reason: Available
      status: "True"
      type: Ready
  
  Rendering examples/xr-cidrnetmask.yaml...
  ---
  apiVersion: platform.upbound.io/v1alpha1
  kind: XCIDR
  metadata:
    name: cidr-netmask
  status:
    atFunction:
      cidr: 255.240.0.0
    conditions:
    - lastTransitionTime: "2024-01-01T00:00:00Z"
      reason: Available
      status: "True"
      type: Ready
  
  Rendering examples/xr-cidrsubnet.yaml...
  ---
  apiVersion: platform.upbound.io/v1alpha1
  kind: XCIDR
  metadata:
    name: cidr-subnet
  status:
    atFunction:
      cidr: 10.0.0.0/28
    conditions:
    - lastTransitionTime: "2024-01-01T00:00:00Z"
      reason: Available
      status: "True"
      type: Ready
  
  Rendering examples/xr-cidrsubnetloop.yaml...
  ---
  apiVersion: platform.upbound.io/v1alpha1
  kind: XCIDR
  metadata:
    name: cidr-subnetloop
  status:
    atFunction:
      cidr:
      - 10.0.0.48/32
      - 10.0.0.49/32
      - 10.0.0.50/32
    conditions:
    - lastTransitionTime: "2024-01-01T00:00:00Z"
      reason: Available
      status: "True"
      type: Ready
  
  Rendering examples/xr-cidrsubnets.yaml...
  ---
  apiVersion: platform.upbound.io/v1alpha1
  kind: XCIDR
  metadata:
    name: cidr-subnets
  status:
    atFunction:
      cidr:
      - 10.0.0.0/28
      - 10.0.1.0/24
      - 10.0.4.0/22
    conditions:
    - lastTransitionTime: "2024-01-01T00:00:00Z"
      reason: Available
      status: "True"
      type: Ready
  
  Rendering examples/xr-multicidrsubnetsloop.yaml...
  ---
  apiVersion: platform.upbound.io/v1alpha1
  kind: XCIDR
  metadata:
    name: cidr-multiprefixloop
  status:
    atFunction:
      cidr:
        10.0.0.0/20:
        - 10.0.0.0/28
        - 10.0.1.0/24
        - 10.0.4.0/22
        127.0.0.0/20:
        - 127.0.0.0/24
        - 127.0.1.0/24
        - 127.0.2.0/24
        - 127.0.3.0/24
        - 127.0.4.0/24
        - 127.0.5.0/24
        - 127.0.6.0/25
        - 127.0.6.128/25
        - 127.0.7.0/25
        - 127.0.7.128/25
        - 127.0.8.0/25
        - 127.0.8.128/25
    conditions:
    - lastTransitionTime: "2024-01-01T00:00:00Z"
      reason: Available
      status: "True"
      type: Ready
  ```
* Output of `make render-pipeline`:
  ```
  crossplane beta render examples/xr-cidrsubnet.yaml \
                    apis/composition-pipeline.yaml \
                          examples/functions.yaml
  ---
  apiVersion: platform.upbound.io/v1alpha1
  kind: XCIDR
  metadata:
    name: cidr-subnet
  status:
    atFunction:
      cidr:
        partitions:
        - 10.0.0.0/21
        - 10.0.8.0/21
        private:
          subnets:
          - 10.0.0.0/22
          - 10.0.4.0/22
        public:
          subnets:
          - 10.0.8.0/22
          - 10.0.12.0/22
    conditions:
    - lastTransitionTime: "2024-01-01T00:00:00Z"
      reason: Available
      status: "True"
      type: Ready
  ```